### PR TITLE
feat(prism): create profiles on first violation only, DM user on creation

### DIFF
--- a/assets/events.py
+++ b/assets/events.py
@@ -424,13 +424,6 @@ async def process_message(message: discord.Message, bot: commands.AutoShardedBot
     stats["prossesed_messages"] = int(stats.get("prossesed_messages", 0)) + 1
     datasys.save_data(1001, "stats", stats)
     try:
-        # Prism: ensure profile exists for every user who sends a message
-        try:
-            _account_age = (datetime.datetime.now(datetime.timezone.utc) - message.author.created_at).days
-            sentinel.ensure_profile(message.author.id, message.author.name, _account_age)
-        except Exception:
-            pass
-
         # Auto-Slowmode check (passive, non-blocking)
         asyncio.create_task(auto_slowmode.check(message))
 

--- a/assets/trust.py
+++ b/assets/trust.py
@@ -408,7 +408,8 @@ def record_event(
     now_dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     account_created_at = (now_dt - datetime.timedelta(days=account_age_days)).isoformat()
 
-    if uid not in data:
+    is_new_profile = uid not in data
+    if is_new_profile:
         data[uid] = {
             "name":               user_name,
             "id":                 uid,
@@ -467,6 +468,10 @@ def record_event(
 
     # Schedule LLM summary update (score always < 100 after any event)
     _schedule_summary_update(uid)
+
+    # Notify the user via DM when their profile is first created (first violation)
+    if is_new_profile:
+        _schedule_user_dm(user_id, user_name)
 
     logger.info(f"[Prism] {user_name} ({uid}) event={event_type} severity={severity} score={score}")
     return score
@@ -677,6 +682,55 @@ async def _send_staff_notification(
         logger.info(f"[Prism] Staff notification sent in {guild.name} for {user_name}")
     except Exception as e:
         logger.error(f"[Prism] Staff notification failed: {e}")
+
+
+def _schedule_user_dm(user_id: int, user_name: str):
+    """Schedule a DM to notify the user that a Prism profile was created for them."""
+    import assets.share as share
+    bot = share.bot
+    if bot is None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_send_user_dm(bot, user_id, user_name))
+    except RuntimeError:
+        pass  # no running loop — skip DM
+
+
+async def _send_user_dm(bot, user_id: int, user_name: str):
+    """Send a DM to a user explaining that a Prism profile was created for them."""
+    import discord
+    import config.config as config
+
+    try:
+        user = await bot.fetch_user(user_id)
+        if user is None:
+            return
+
+        embed = discord.Embed(
+            title=f"{config.Icons.info} Your PRISM Profile Has Been Created",
+            description=(
+                "A moderation event on one of the servers you share with Baxi has triggered "
+                "the creation of a **PRISM** profile for your account.\n\n"
+                "**What is PRISM?**\n"
+                "PRISM is Baxi's automated trust-scoring system. It tracks moderation events "
+                "across servers and calculates a trust score (0–100) to help moderators make "
+                "informed decisions. Your score starts at 100 and is adjusted based on "
+                "moderation history.\n\n"
+                "**What can you do?**\n"
+                "• `/my_trust` — View your current trust score and recent events\n"
+                "• `/prism-optout` — Opt out of PRISM tracking at any time\n\n"
+                "**Learn more:**\n"
+                "https://baxi.avocloud.net/docs/user-guide/prism"
+            ),
+            color=config.Discord.info_color,
+        )
+        embed.set_footer(text="Baxi PRISM · avocloud.net")
+
+        await user.send(embed=embed)
+        logger.info(f"[Prism] DM sent to {user_name} ({user_id}) on profile creation")
+    except Exception as e:
+        logger.warn(f"[Prism] Could not send DM to {user_name} ({user_id}): {e}")
 
 
 async def _resolve_notification_channel(guild):

--- a/assets/trust.py
+++ b/assets/trust.py
@@ -710,20 +710,49 @@ async def _send_user_dm(bot, user_id: int, user_name: str):
         embed = discord.Embed(
             title=f"{config.Icons.info} Your PRISM Profile Has Been Created",
             description=(
-                "A moderation event on one of the servers you share with Baxi has triggered "
-                "the creation of a **PRISM** profile for your account.\n\n"
-                "**What is PRISM?**\n"
-                "PRISM is Baxi's automated trust-scoring system. It tracks moderation events "
-                "across servers and calculates a trust score (0–100) to help moderators make "
-                "informed decisions. Your score starts at 100 and is adjusted based on "
-                "moderation history.\n\n"
-                "**What can you do?**\n"
-                "• `/my_trust` — View your current trust score and recent events\n"
-                "• `/prism-optout` — Opt out of PRISM tracking at any time\n\n"
-                "**Learn more:**\n"
-                "https://baxi.avocloud.net/docs/user-guide/prism"
+                "A moderation event on a server you share with Baxi has triggered the creation "
+                "of a **PRISM** profile for your account. This message is to keep you informed."
             ),
             color=config.Discord.info_color,
+        )
+        embed.add_field(
+            name="What is PRISM?",
+            value=(
+                "PRISM is Baxi's cross-server trust-scoring system. It assigns every tracked user "
+                "a score from 0 to 100 based on their moderation history. Moderators can use this "
+                "score as one signal among many to make fairer, more consistent decisions — "
+                "especially for users who are new to a server."
+            ),
+            inline=False,
+        )
+        embed.add_field(
+            name="Why does this exist?",
+            value=(
+                "Moderation context is often lost when a user joins a new server. PRISM helps "
+                "moderators avoid repeat harm from bad actors while also giving well-behaved users "
+                "a positive track record that follows them. Scores recover over time as long as "
+                "no new violations occur, so one-off incidents don't define you permanently."
+            ),
+            inline=False,
+        )
+        embed.add_field(
+            name="Your privacy",
+            value=(
+                "PRISM stores only the minimum data necessary: a list of moderation event types, "
+                "their timestamps, and the server they occurred on. No message content, "
+                "no personal information, and no data beyond what directly relates to moderation "
+                "actions is ever saved."
+            ),
+            inline=False,
+        )
+        embed.add_field(
+            name="What can you do?",
+            value=(
+                "• `/my_trust` — View your current score and recent events\n"
+                "• `/prism-optout` — Opt out of PRISM tracking at any time\n"
+                "• [Documentation](https://baxi.avocloud.net/docs/user-guide/prism) — Full details on how PRISM works"
+            ),
+            inline=False,
         )
         embed.set_footer(text="Baxi PRISM · avocloud.net")
 

--- a/assets/trust.py
+++ b/assets/trust.py
@@ -471,7 +471,7 @@ def record_event(
 
     # Notify the user via DM when their profile is first created (first violation)
     if is_new_profile:
-        _schedule_user_dm(user_id, user_name)
+        _schedule_user_dm(user_id, user_name, guild_id)
 
     logger.info(f"[Prism] {user_name} ({uid}) event={event_type} severity={severity} score={score}")
     return score
@@ -684,7 +684,7 @@ async def _send_staff_notification(
         logger.error(f"[Prism] Staff notification failed: {e}")
 
 
-def _schedule_user_dm(user_id: int, user_name: str):
+def _schedule_user_dm(user_id: int, user_name: str, guild_id: int):
     """Schedule a DM to notify the user that a Prism profile was created for them."""
     import assets.share as share
     bot = share.bot
@@ -692,69 +692,35 @@ def _schedule_user_dm(user_id: int, user_name: str):
         return
     try:
         loop = asyncio.get_running_loop()
-        loop.create_task(_send_user_dm(bot, user_id, user_name))
+        loop.create_task(_send_user_dm(bot, user_id, user_name, guild_id))
     except RuntimeError:
         pass  # no running loop — skip DM
 
 
-async def _send_user_dm(bot, user_id: int, user_name: str):
+async def _send_user_dm(bot, user_id: int, user_name: str, guild_id: int):
     """Send a DM to a user explaining that a Prism profile was created for them."""
     import discord
     import config.config as config
+    import assets.data as _datasys
 
     try:
         user = await bot.fetch_user(user_id)
         if user is None:
             return
 
+        lang = _datasys.load_lang_file(guild_id)
+        t = lang.get("commands", {}).get("user", {}).get("prism_profile_created_dm", {})
+
         embed = discord.Embed(
-            title=f"{config.Icons.info} Your PRISM Profile Has Been Created",
-            description=(
-                "A moderation event on a server you share with Baxi has triggered the creation "
-                "of a **PRISM** profile for your account. This message is to keep you informed."
-            ),
+            title=f"{config.Icons.info} {t.get('title', 'Your PRISM Profile Has Been Created')}",
+            description=t.get("description", ""),
             color=config.Discord.info_color,
         )
-        embed.add_field(
-            name="What is PRISM?",
-            value=(
-                "PRISM is Baxi's cross-server trust-scoring system. It assigns every tracked user "
-                "a score from 0 to 100 based on their moderation history. Moderators can use this "
-                "score as one signal among many to make fairer, more consistent decisions — "
-                "especially for users who are new to a server."
-            ),
-            inline=False,
-        )
-        embed.add_field(
-            name="Why does this exist?",
-            value=(
-                "Moderation context is often lost when a user joins a new server. PRISM helps "
-                "moderators avoid repeat harm from bad actors while also giving well-behaved users "
-                "a positive track record that follows them. Scores recover over time as long as "
-                "no new violations occur, so one-off incidents don't define you permanently."
-            ),
-            inline=False,
-        )
-        embed.add_field(
-            name="Your privacy",
-            value=(
-                "PRISM stores only the minimum data necessary: a list of moderation event types, "
-                "their timestamps, and the server they occurred on. No message content, "
-                "no personal information, and no data beyond what directly relates to moderation "
-                "actions is ever saved."
-            ),
-            inline=False,
-        )
-        embed.add_field(
-            name="What can you do?",
-            value=(
-                "• `/my_trust` — View your current score and recent events\n"
-                "• `/prism-optout` — Opt out of PRISM tracking at any time\n"
-                "• [Documentation](https://baxi.avocloud.net/docs/user-guide/prism) — Full details on how PRISM works"
-            ),
-            inline=False,
-        )
-        embed.set_footer(text="Baxi PRISM · avocloud.net")
+        embed.add_field(name=t.get("what_is_title", ""), value=t.get("what_is_value", ""), inline=False)
+        embed.add_field(name=t.get("why_title", ""),     value=t.get("why_value", ""),     inline=False)
+        embed.add_field(name=t.get("privacy_title", ""), value=t.get("privacy_value", ""), inline=False)
+        embed.add_field(name=t.get("actions_title", ""), value=t.get("actions_value", ""), inline=False)
+        embed.set_footer(text=t.get("footer", "Baxi PRISM · avocloud.net"))
 
         await user.send(embed=embed)
         logger.info(f"[Prism] DM sent to {user_name} ({user_id}) on profile creation")

--- a/lang/lang.json
+++ b/lang/lang.json
@@ -59,6 +59,19 @@
                     "opted_out": "Du hast dich erfolgreich von Prism abgemeldet. Dein Vertrauens-Score wird nicht mehr geführt.\n\n**Bitte beachte:**\n• Server-Administratoren können sehen, dass du Opt-Out gewählt hast.\n• Moderation (Chatfilter, Anti-Spam usw.) bleibt weiterhin aktiv — nur Prism führt keinen Score mehr über dich.",
                     "opted_in": "Du hast dich wieder bei Prism angemeldet. Dein Vertrauens-Score wird ab sofort wieder geführt.",
                     "footer": "Baxi Prism · avocloud.net"
+                },
+                "prism_profile_created_dm": {
+                    "title": "Dein PRISM-Profil wurde erstellt",
+                    "description": "Ein Moderationsereignis auf einem Server, den du mit Baxi teilst, hat die Erstellung eines **PRISM**-Profils für deinen Account ausgelöst. Diese Nachricht dient dazu, dich darüber zu informieren.",
+                    "what_is_title": "Was ist PRISM?",
+                    "what_is_value": "PRISM ist Baxis serverübergreifendes Vertrauens-Bewertungssystem. Es berechnet einen Score von 0 bis 100 anhand deiner Moderationshistorie. Moderatoren können diesen Score als einen von mehreren Hinweisen nutzen, um fairere und konsistentere Entscheidungen zu treffen – besonders wenn du einem neuen Server beitrittst.",
+                    "why_title": "Wozu ist das gut?",
+                    "why_value": "Moderationskontext geht oft verloren, wenn jemand einem neuen Server beitritt. PRISM hilft Moderatoren, wiederholten Schaden durch regelwidrige Nutzer zu verhindern – und gibt regelkonformen Nutzern eine positive Bilanz, die sie mitnehmen können. Scores erholen sich automatisch mit der Zeit, solange keine neuen Verstöße auftreten. Ein einzelner Vorfall bestimmt dich also nicht dauerhaft.",
+                    "privacy_title": "Deine Privatsphäre",
+                    "privacy_value": "PRISM speichert ausschließlich das Minimum: Art des Moderationsereignisses, Zeitstempel und der Server, auf dem es stattfand. Kein Nachrichteninhalt, keine persönlichen Daten – nur direkt moderationsrelevante Informationen.",
+                    "actions_title": "Was kannst du tun?",
+                    "actions_value": "• `/my_trust` — Deinen aktuellen Score und vergangene Ereignisse anzeigen\n• `/prism-optout` — PRISM-Tracking jederzeit deaktivieren\n• [Dokumentation](https://baxi.avocloud.net/docs/user-guide/prism) — Alle Details zur Funktionsweise von PRISM",
+                    "footer": "Baxi PRISM · avocloud.net"
                 }
             },
             "admin": {
@@ -319,6 +332,19 @@
                     "opted_out": "You have successfully opted out of Prism. Your trust score will no longer be tracked.\n\n**Please note:**\n• Server administrators can see that you have opted out.\n• Moderation (chat filter, anti-spam, etc.) remains fully active — only Prism will no longer track a score for you.",
                     "opted_in": "You have opted back in to Prism. Your trust score will now be tracked again.",
                     "footer": "Baxi Prism · avocloud.net"
+                },
+                "prism_profile_created_dm": {
+                    "title": "Your PRISM Profile Has Been Created",
+                    "description": "A moderation event on a server you share with Baxi has triggered the creation of a **PRISM** profile for your account. This message is to keep you informed.",
+                    "what_is_title": "What is PRISM?",
+                    "what_is_value": "PRISM is Baxi's cross-server trust-scoring system. It calculates a score from 0 to 100 based on your moderation history. Moderators can use this score as one signal among many to make fairer, more consistent decisions — especially when you join a new server.",
+                    "why_title": "Why does this exist?",
+                    "why_value": "Moderation context is often lost when someone joins a new server. PRISM helps moderators avoid repeat harm from bad actors, while giving well-behaved users a positive track record that follows them. Scores recover automatically over time as long as no new violations occur — one-off incidents don't define you permanently.",
+                    "privacy_title": "Your privacy",
+                    "privacy_value": "PRISM stores only the minimum necessary: the type of moderation event, its timestamp, and the server it occurred on. No message content, no personal information — only data directly related to moderation actions.",
+                    "actions_title": "What can you do?",
+                    "actions_value": "• `/my_trust` — View your current score and recent events\n• `/prism-optout` — Opt out of PRISM tracking at any time\n• [Documentation](https://baxi.avocloud.net/docs/user-guide/prism) — Full details on how PRISM works",
+                    "footer": "Baxi PRISM · avocloud.net"
                 }
             },
             "admin": {


### PR DESCRIPTION
- Remove ensure_profile() call from process_message() so PRISM no longer
  creates profiles for every user who sends a message.
- Track is_new_profile in record_event() to detect first-violation creation.
- Add _schedule_user_dm() / _send_user_dm() that fire an info embed DM to the
  user when their profile is first created, explaining PRISM, how to check
  their score (/my_trust), how to opt out (/prism-optout), and linking to
  https://baxi.avocloud.net/docs/user-guide/prism.

https://claude.ai/code/session_01PoxmzowKR3rTh2FvtHxEq5