### PR TITLE
feat(admin): expand user search to all logs, English DM, full data detail

### DIFF
--- a/assets/dash/dash.py
+++ b/assets/dash/dash.py
@@ -2636,13 +2636,17 @@ def dash_web(app: quart.Quart, bot: commands.AutoShardedBot):
             # Prism profile
             profile = sentinel.get_profile(int(uid_str))
             if profile:
+                _prism_events = profile.get("events", [])
                 result["prism"] = {
                     "score": profile.get("score", 100),
-                    "event_count": len(profile.get("events", [])),
+                    "event_count": len(_prism_events),
                     "first_seen": profile.get("first_seen", ""),
                     "last_seen": profile.get("last_seen", ""),
+                    "account_created_at": profile.get("account_created_at", ""),
                     "auto_flagged": profile.get("auto_flagged", False),
                     "opted_out": profile.get("opted_out", False),
+                    "risk_signals": profile.get("risk_signals", []),
+                    "events": _prism_events[-30:],
                 }
 
             # Flagged entry
@@ -2686,6 +2690,7 @@ def dash_web(app: quart.Quart, bot: commands.AutoShardedBot):
                             "guild_id": _gid,
                             "guild_name": _conf.get("guild_name", _gid),
                             "count": len(_warns),
+                            "entries": _warns,
                         })
                 except Exception:
                     pass
@@ -2713,6 +2718,77 @@ def dash_web(app: quart.Quart, bot: commands.AutoShardedBot):
                 except Exception:
                     pass
             result["temp_actions"] = temp_actions_found
+
+            # GC ban / BA ban (global)
+            _global_conf_path = os.path.join("data", "1001", "conf.json")
+            result["gc_ban"] = None
+            result["ba_ban"] = None
+            try:
+                with open(_global_conf_path, "r", encoding="utf-8") as _gcf:
+                    _global_conf = json.load(_gcf)
+                _gc_ban_map = _global_conf.get("gc_ban", {})
+                _ba_ban_map = _global_conf.get("ba_ban", {})
+                if uid_str in _gc_ban_map:
+                    result["gc_ban"] = _gc_ban_map[uid_str]
+                if uid_str in _ba_ban_map:
+                    result["ba_ban"] = _ba_ban_map[uid_str]
+            except Exception:
+                pass
+
+            # Open tickets per guild
+            open_tickets_found = []
+            for _gid in _guild_dirs:
+                _tk_path = os.path.join(_data_dir, _gid, "tickets.json")
+                if not os.path.exists(_tk_path):
+                    continue
+                try:
+                    with open(_tk_path, "r", encoding="utf-8") as _tf:
+                        _open_tks = json.load(_tf)
+                    _gname_tk = None
+                    for _cid, _td in _open_tks.items():
+                        if str(_td.get("user", "")) == uid_str:
+                            if _gname_tk is None:
+                                try:
+                                    with open(os.path.join(_data_dir, _gid, "conf.json"), encoding="utf-8") as _fcf:
+                                        _gname_tk = json.load(_fcf).get("guild_name", _gid)
+                                except Exception:
+                                    _gname_tk = _gid
+                            open_tickets_found.append({
+                                "guild_id": _gid,
+                                "guild_name": _gname_tk,
+                                "channel_id": _cid,
+                                "title": _td.get("title", ""),
+                                "message": _td.get("message", ""),
+                                "status": _td.get("status", "open"),
+                                "created_at": _td.get("created_at", ""),
+                            })
+                except Exception:
+                    pass
+            result["open_tickets"] = open_tickets_found
+
+            # Closed transcripts (match by username in messages)
+            transcripts_found = []
+            if found_name:
+                _name_lower = found_name.lower()
+                try:
+                    _transcripts: dict = dict(datasys.load_data(1001, "transcripts"))
+                    for _tid, _tr in _transcripts.items():
+                        _tr_msgs = _tr.get("transcript", [])
+                        for _trm in _tr_msgs:
+                            if _trm.get("user", "").lower() == _name_lower:
+                                transcripts_found.append({
+                                    "id": _tid,
+                                    "guild_id": _tr.get("guild", ""),
+                                    "title": _tr.get("title", ""),
+                                    "initial_message": _tr.get("msg", ""),
+                                    "closed_by": _tr.get("closed_by", ""),
+                                    "closed_on": _tr.get("closed_on", ""),
+                                    "message_count": len(_tr_msgs),
+                                })
+                                break
+                except Exception:
+                    pass
+            result["transcripts"] = transcripts_found
 
             share.admin_log("info", f"User search for '{query}' by {user.name} → found uid={uid_str}", source="AdminDash")
             return quart.jsonify(result)
@@ -2813,16 +2889,16 @@ def dash_web(app: quart.Quart, bot: commands.AutoShardedBot):
                 target_del = await bot.fetch_user(int(user_id_str))
                 _ts_del = datetime.now(_VIENNA).strftime("%d.%m.%Y %H:%M")
                 embed_del = discord.Embed(
-                    title="Deine Daten wurden gelöscht",
+                    title="Your Data has been deleted",
                     description=(
-                        "Alle in Baxi über dich gespeicherten Daten wurden von einem Administrator gelöscht.\n\n"
-                        f"**Gelöscht:** {', '.join(deleted_items) if deleted_items else 'Keine Daten gefunden'}\n"
-                        f"**Gelöscht am:** {_ts_del}\n\n"
-                        "Falls du glaubst, dass dies ein Fehler war, wende dich bitte an das Baxi-Support-Team."
+                        "All data stored about you in Baxi has been deleted by an administrator.\n\n"
+                        f"**Deleted:** {', '.join(deleted_items) if deleted_items else 'No data found'}\n"
+                        f"**Deleted on:** {_ts_del}\n\n"
+                        "If you believe this was done in error, please contact the Baxi support team."
                     ),
                     color=config.Discord.color,
                 )
-                embed_del.set_author(name="Baxi Datenverwaltung")
+                embed_del.set_author(name="Baxi Data Management")
                 embed_del.set_footer(text="Avocloud.net · Baxi")
                 await target_del.send(embed=embed_del)
                 dm_sent = True
@@ -2861,7 +2937,10 @@ def dash_web(app: quart.Quart, bot: commands.AutoShardedBot):
             users_list_rep: dict = dict(datasys.load_data(1001, "users"))
             flagged_rep = users_list_rep.get(user_id_str)
             cf_log_rep: dict = dict(datasys.load_data(1001, "chatfilter_log"))
-            violations_rep = [v for v in cf_log_rep.values() if str(v.get("uid", "")) == user_id_str]
+            violations_rep = sorted(
+                [v for v in cf_log_rep.values() if str(v.get("uid", "")) == user_id_str],
+                key=lambda v: v.get("timestamp", ""), reverse=True
+            )
 
             _data_dir3 = "data"
             try:
@@ -2872,7 +2951,7 @@ def dash_web(app: quart.Quart, bot: commands.AutoShardedBot):
             except FileNotFoundError:
                 _guild_dirs3 = []
 
-            total_warnings_rep = 0
+            all_warnings_rep: list[dict] = []
             for _gid3 in _guild_dirs3:
                 _cp3 = os.path.join(_data_dir3, _gid3, "conf.json")
                 if not os.path.exists(_cp3):
@@ -2880,56 +2959,160 @@ def dash_web(app: quart.Quart, bot: commands.AutoShardedBot):
                 try:
                     with open(_cp3, "r", encoding="utf-8") as _f4:
                         _conf3 = json.load(_f4)
-                    total_warnings_rep += len(_conf3.get("warnings", {}).get(user_id_str, []))
+                    _gw = _conf3.get("warnings", {}).get(user_id_str, [])
+                    _gname3 = _conf3.get("guild_name", _gid3)
+                    for _w in _gw:
+                        all_warnings_rep.append({**_w, "guild_name": _gname3, "guild_id": _gid3})
                 except Exception:
                     pass
 
-            lines_rep = []
+            temp_actions_rep: list[dict] = []
+            for _gid3 in _guild_dirs3:
+                _tp3 = os.path.join(_data_dir3, _gid3, "temp_actions.json")
+                if not os.path.exists(_tp3):
+                    continue
+                try:
+                    with open(_tp3, "r", encoding="utf-8") as _f5:
+                        _ta3 = json.load(_f5)
+                    for _at3 in ["bans", "timeouts"]:
+                        for _te3 in _ta3.get(_at3, []):
+                            if str(_te3.get("user_id", "")) == user_id_str:
+                                temp_actions_rep.append({
+                                    "type": _at3[:-1],
+                                    "guild_name": _te3.get("guild_name", _gid3),
+                                    "expires_at": _te3.get("expires_at", ""),
+                                    "reason": _te3.get("reason", ""),
+                                })
+                except Exception:
+                    pass
+
+            embeds_to_send: list[discord.Embed] = []
+
+            # ── Embed 1: Overview ─────────────────────────────────────────
+            overview_lines = [
+                "The following data is stored about you in the Baxi bot system.",
+                "This information is used for moderation and trust-scoring purposes.\n",
+            ]
             if profile_rep:
-                lines_rep.append(f"**Prism Score:** {profile_rep.get('score', 100)}/100")
-                lines_rep.append(f"**Prism Events:** {len(profile_rep.get('events', []))}")
-                lines_rep.append(f"**Auto-flagged:** {'Ja' if profile_rep.get('auto_flagged') else 'Nein'}")
+                _score = profile_rep.get("score", 100)
+                _flag_txt = " ⚠️ Auto-flagged" if profile_rep.get("auto_flagged") else ""
+                overview_lines.append(f"**Prism Trust Score:** {_score}/100{_flag_txt}")
+                overview_lines.append(f"**Prism Events recorded:** {len(profile_rep.get('events', []))}")
                 if profile_rep.get("first_seen"):
-                    lines_rep.append(f"**Erstmals von Baxi gesehen:** {profile_rep['first_seen'][:10]}")
+                    overview_lines.append(f"**First seen by Baxi:** {profile_rep['first_seen'][:10]}")
                 if profile_rep.get("last_seen"):
-                    lines_rep.append(f"**Zuletzt von Baxi gesehen:** {profile_rep['last_seen'][:10]}")
+                    overview_lines.append(f"**Last seen by Baxi:** {profile_rep['last_seen'][:10]}")
+                if profile_rep.get("account_created_at"):
+                    overview_lines.append(f"**Account created:** {profile_rep['account_created_at'][:10]}")
                 if profile_rep.get("opted_out"):
-                    lines_rep.append("**Prism Opt-out:** Ja")
+                    overview_lines.append("**Prism tracking:** Opted out")
+                _rsig = profile_rep.get("risk_signals", [])
+                if _rsig:
+                    overview_lines.append(f"**Active risk signals:** {', '.join(_rsig)}")
             if flagged_rep and flagged_rep.get("flagged"):
-                lines_rep.append(f"**Global gemeldet:** Ja (Grund: {flagged_rep.get('reason', '—')})")
-            if violations_rep:
-                lines_rep.append(f"**Chatfilter-Verstöße:** {len(violations_rep)}")
-            if total_warnings_rep:
-                lines_rep.append(f"**Verwarnungen (gesamt über alle Server):** {total_warnings_rep}")
+                overview_lines.append(f"**Global flag:** Yes — Reason: {flagged_rep.get('reason', '—')}")
+                if flagged_rep.get("entry_date"):
+                    overview_lines.append(f"**Flagged on:** {flagged_rep['entry_date']}")
+            overview_lines.append(f"\n**Chatfilter violations:** {len(violations_rep)}")
+            overview_lines.append(f"**Warnings across all servers:** {len(all_warnings_rep)}")
+            overview_lines.append(f"**Active temp actions:** {len(temp_actions_rep)}")
 
-            if not lines_rep:
-                lines_rep.append("Keine Daten über dich im Baxi-System gespeichert.")
-
-            embed_rep = discord.Embed(
-                title="Deine bei Baxi gespeicherten Daten",
-                description=(
-                    "Folgende Daten sind über dich im Baxi-Bot-System gespeichert. "
-                    "Diese Informationen werden für Moderations- und Trust-Scoring-Zwecke verwendet.\n\n"
-                    + "\n".join(lines_rep)
-                ),
+            embed_overview = discord.Embed(
+                title="Your Data stored in Baxi",
+                description="\n".join(overview_lines),
                 color=config.Discord.color,
             )
-            embed_rep.set_author(name="Baxi Datenbericht")
-            embed_rep.set_footer(text=f"Angefordert am {_ts_rep} · Avocloud.net · Baxi")
+            embed_overview.set_author(name="Baxi Data Report")
+            embed_overview.set_footer(text=f"Requested on {_ts_rep} · Avocloud.net · Baxi")
+            embeds_to_send.append(embed_overview)
+
+            # ── Embed 2: Prism events ────────────────────────────────────
+            if profile_rep and profile_rep.get("events"):
+                _evs = profile_rep["events"][-20:]
+                ev_lines = []
+                for _ev in reversed(_evs):
+                    _ev_ts = str(_ev.get("timestamp", ""))[:16].replace("T", " ")
+                    _ev_type = _ev.get("type", "unknown")
+                    _ev_reason = _ev.get("reason", "—")
+                    _ev_guild = _ev.get("guild_id", "")
+                    ev_lines.append(f"`{_ev_ts}` **{_ev_type}** — {_ev_reason} *(server {_ev_guild})*")
+                embed_events = discord.Embed(
+                    title="Prism Events (last 20)",
+                    description="\n".join(ev_lines) or "No events recorded.",
+                    color=0x9333ea,
+                )
+                embeds_to_send.append(embed_events)
+
+            # ── Embed 3: Chatfilter violations ───────────────────────────
+            if violations_rep:
+                cf_lines = []
+                for _viol in violations_rep[:15]:
+                    _vts = _viol.get("timestamp", "—")
+                    _vsname = _viol.get("sname", "—")
+                    _vreason = _viol.get("reason", "—")
+                    _vmsg = (_viol.get("message", "") or "")[:80]
+                    cf_lines.append(f"`{_vts}` **{_vsname}** — *{_vreason}*\n> {_vmsg}")
+                if len(violations_rep) > 15:
+                    cf_lines.append(f"*… and {len(violations_rep) - 15} more violations*")
+                embed_cf = discord.Embed(
+                    title=f"Chatfilter Violations ({len(violations_rep)})",
+                    description="\n\n".join(cf_lines),
+                    color=0xc084fc,
+                )
+                embeds_to_send.append(embed_cf)
+
+            # ── Embed 4: Warnings ────────────────────────────────────────
+            if all_warnings_rep:
+                warn_lines = []
+                for _warn in all_warnings_rep[:20]:
+                    _wdate = _warn.get("date", "—")
+                    _wreason = _warn.get("reason", "—")
+                    _wmod = _warn.get("mod", "—")
+                    _wguild = _warn.get("guild_name", "—")
+                    warn_lines.append(f"`{_wdate}` **{_wguild}** — {_wreason} *(by {_wmod})*")
+                if len(all_warnings_rep) > 20:
+                    warn_lines.append(f"*… and {len(all_warnings_rep) - 20} more warnings*")
+                embed_warns = discord.Embed(
+                    title=f"Warnings ({len(all_warnings_rep)} total)",
+                    description="\n".join(warn_lines),
+                    color=0xfb923c,
+                )
+                embeds_to_send.append(embed_warns)
+
+            # ── Embed 5: Temp actions ────────────────────────────────────
+            if temp_actions_rep:
+                ta_lines = []
+                for _ta_r in temp_actions_rep:
+                    _ta_type = _ta_r.get("type", "—").upper()
+                    _ta_guild = _ta_r.get("guild_name", "—")
+                    _ta_exp = _ta_r.get("expires_at", "—")
+                    _ta_reason = _ta_r.get("reason", "—")
+                    ta_lines.append(f"**{_ta_type}** in {_ta_guild}\nExpires: `{_ta_exp}` — {_ta_reason}")
+                embed_ta = discord.Embed(
+                    title=f"Active Temp Actions ({len(temp_actions_rep)})",
+                    description="\n\n".join(ta_lines),
+                    color=0xf87171,
+                )
+                embeds_to_send.append(embed_ta)
+
+            if len(embeds_to_send) == 1:
+                embed_overview.description += "\n\n*No detailed records found beyond this summary.*"
 
             try:
-                await target_rep.send(embed=embed_rep)
+                # Discord allows max 10 embeds per message; send in batches of 10
+                for _i in range(0, len(embeds_to_send), 10):
+                    await target_rep.send(embeds=embeds_to_send[_i:_i + 10])
             except discord.Forbidden:
-                return quart.jsonify({"success": False, "message": "DM konnte nicht gesendet werden — User hat DMs deaktiviert."}), 400
+                return quart.jsonify({"success": False, "message": "Could not send DM — user has DMs disabled."}), 400
             except Exception as _e2:
-                return quart.jsonify({"success": False, "message": f"Fehler beim Senden der DM: {_e2}"}), 500
+                return quart.jsonify({"success": False, "message": f"Error sending DM: {_e2}"}), 500
 
             share.admin_log(
                 "info",
-                f"Datenbericht an {target_rep.name} ({user_id_str}) gesendet von {user.name}",
+                f"Data report sent to {target_rep.name} ({user_id_str}) by {user.name}",
                 source="AdminDash",
             )
-            return quart.jsonify({"success": True, "message": f"Datenbericht via DM an {target_rep.name} gesendet."})
+            return quart.jsonify({"success": True, "message": f"Data report sent via DM to {target_rep.name}."})
 
         return quart.jsonify({"success": False, "message": f"Unknown action: {action}"}), 400
 

--- a/assets/dash/web/admin.html
+++ b/assets/dash/web/admin.html
@@ -506,13 +506,13 @@
         <div class="section-badge">User Search &amp; Data Management</div>
         <div class="card">
             <header>
-                <h2 style="font-size:1rem; font-weight:600;">User durchsuchen</h2>
-                <p style="font-size:.78rem; opacity:.5; margin-top:.15rem;">Suche nach Name oder Discord User-ID in allen Systemen: Prism, Flags, Chatfilter, Verwarnungen, Temp-Actions.</p>
+                <h2 style="font-size:1rem; font-weight:600;">User Search</h2>
+                <p style="font-size:.78rem; opacity:.5; margin-top:.15rem;">Search by name or Discord User-ID across all systems: Prism, Flags, Chatfilter, Warnings, Temp-Actions, Tickets, Transcripts, Global Bans.</p>
             </header>
             <section>
                 <div style="display:flex; gap:.5rem; margin-bottom:1rem;">
-                    <input id="user-search-query" type="text" placeholder="Username oder User-ID…" style="flex:1;" onkeydown="if(event.key==='Enter') searchUser()">
-                    <button onclick="searchUser()" class="btn-primary">Suchen</button>
+                    <input id="user-search-query" type="text" placeholder="Username or User-ID…" style="flex:1;" onkeydown="if(event.key==='Enter') searchUser()">
+                    <button onclick="searchUser()" class="btn-primary">Search</button>
                 </div>
                 <div id="user-search-result" class="action-result"></div>
                 <div id="user-search-wrap" style="display:none;">
@@ -523,13 +523,13 @@
                             <div id="user-search-id" style="font-size:.72rem; opacity:.4; margin-top:.1rem;"></div>
                         </div>
                         <div style="display:flex; gap:.5rem; flex-wrap:wrap;">
-                            <button id="btn-send-data" onclick="sendUserData()" class="btn-sm-outline" style="color:#60a5fa;" title="Sendet alle gespeicherten Daten per DM an den User">
+                            <button id="btn-send-data" onclick="sendUserData()" class="btn-sm-outline" style="color:#60a5fa;" title="Send all stored data to the user via DM">
                                 <svg viewBox="0 0 24 24" style="width:13px;height:13px;display:inline;vertical-align:middle;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;margin-right:.3rem;"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
-                                Daten per DM senden
+                                Send Data via DM
                             </button>
-                            <button id="btn-delete-data" onclick="deleteUserData()" class="btn-sm-outline" style="color:#f87171;" title="Löscht alle Daten des Users und sendet eine DM">
+                            <button id="btn-delete-data" onclick="deleteUserData()" class="btn-sm-outline" style="color:#f87171;" title="Delete all user data and send a DM">
                                 <svg viewBox="0 0 24 24" style="width:13px;height:13px;display:inline;vertical-align:middle;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;margin-right:.3rem;"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>
-                                Alle Daten löschen
+                                Delete All Data
                             </button>
                         </div>
                     </div>
@@ -1132,19 +1132,19 @@ let _currentSearchName = null;
 
 async function searchUser() {
     const query = document.getElementById('user-search-query').value.trim();
-    if (!query) { setResult('user-search-result', 'Bitte Username oder User-ID eingeben.', false); return; }
+    if (!query) { setResult('user-search-result', 'Please enter a username or User-ID.', false); return; }
 
     const wrap = document.getElementById('user-search-wrap');
     wrap.style.display = 'none';
     const resultEl = document.getElementById('user-search-result');
     resultEl.className = 'action-result ok';
-    resultEl.textContent = 'Suche läuft…';
+    resultEl.textContent = 'Searching…';
 
     const r = await doAction({ action: 'search_user', query });
     if (!r.ok) { setResult('user-search-result', r.message, false); return; }
 
     if (!r.data.found) {
-        setResult('user-search-result', 'Keine Daten für diesen User gefunden.', false);
+        setResult('user-search-result', 'No data found for this user.', false);
         return;
     }
 
@@ -1160,17 +1160,37 @@ async function searchUser() {
     // Prism profile block
     if (r.data.prism) {
         const p = r.data.prism;
+        const evRows = (p.events||[]).slice().reverse().map(ev => {
+            const ts = ev.timestamp ? ev.timestamp.slice(0,16).replace('T',' ') : '—';
+            return `<tr>
+                <td style="opacity:.5; white-space:nowrap; font-size:.73rem;">${escHtml(ts)}</td>
+                <td style="font-size:.75rem; font-weight:600;">${escHtml(ev.type||'—')}</td>
+                <td style="opacity:.65; font-size:.74rem; word-break:break-word; max-width:220px;">${escHtml(ev.reason||'—')}</td>
+                <td style="opacity:.4; font-size:.72rem;">${escHtml(ev.guild_id||'—')}</td>
+            </tr>`;
+        }).join('');
+        const riskHtml = (p.risk_signals||[]).length
+            ? (p.risk_signals.map(s => `<span class="badge badge-auto" style="font-size:.68rem;">${escHtml(s)}</span>`).join(' '))
+            : '';
         sections.insertAdjacentHTML('beforeend', `
-        <div style="border:1px solid rgba(255,255,255,.08); border-radius:8px; padding:.75rem 1rem;">
-            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Prism Profil</div>
-            <div style="display:flex; flex-wrap:wrap; gap:.4rem .75rem; font-size:.82rem; align-items:center;">
+        <div style="border:1px solid rgba(147,51,234,.25); border-radius:8px; padding:.75rem 1rem;">
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.6rem;">Prism Profile</div>
+            <div style="display:flex; flex-wrap:wrap; gap:.4rem .75rem; font-size:.82rem; align-items:center; margin-bottom:.6rem;">
                 <span>Score: ${scoreBadge(p.score)}</span>
                 <span style="opacity:.6;">Events: <b>${p.event_count}</b></span>
-                ${p.first_seen ? `<span style="opacity:.5; font-size:.75rem;">Erstmals: ${escHtml(p.first_seen.slice(0,10))}</span>` : ''}
-                ${p.last_seen  ? `<span style="opacity:.5; font-size:.75rem;">Zuletzt: ${escHtml(p.last_seen.slice(0,10))}</span>`  : ''}
+                ${p.first_seen ? `<span style="opacity:.5; font-size:.75rem;">First seen: ${escHtml(p.first_seen.slice(0,10))}</span>` : ''}
+                ${p.last_seen  ? `<span style="opacity:.5; font-size:.75rem;">Last seen: ${escHtml(p.last_seen.slice(0,10))}</span>` : ''}
+                ${p.account_created_at ? `<span style="opacity:.5; font-size:.75rem;">Account created: ${escHtml(p.account_created_at.slice(0,10))}</span>` : ''}
                 ${p.auto_flagged ? '<span class="badge badge-auto">Auto-flagged</span>' : ''}
-                ${p.opted_out   ? '<span class="badge badge-idle">Opted out</span>'    : ''}
+                ${p.opted_out   ? '<span class="badge badge-idle">Opted out</span>' : ''}
             </div>
+            ${riskHtml ? `<div style="margin-bottom:.6rem; display:flex; flex-wrap:wrap; gap:.3rem;">${riskHtml}</div>` : ''}
+            ${evRows ? `<div style="overflow-x:auto; margin-top:.4rem;">
+                <table class="admin-table" style="font-size:.75rem;">
+                    <thead><tr><th>Timestamp</th><th>Type</th><th>Reason</th><th>Server ID</th></tr></thead>
+                    <tbody>${evRows}</tbody>
+                </table>
+            </div>` : ''}
         </div>`);
     }
 
@@ -1179,49 +1199,74 @@ async function searchUser() {
         const f = r.data.flagged_entry;
         sections.insertAdjacentHTML('beforeend', `
         <div style="border:1px solid rgba(239,68,68,.25); border-radius:8px; padding:.75rem 1rem;">
-            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Flagged-User-Eintrag</div>
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Global Flag Entry</div>
             <div style="display:flex; flex-wrap:wrap; gap:.4rem .75rem; font-size:.82rem; align-items:center;">
-                <span style="opacity:.7;">Grund: <span style="color:#fb923c;">${escHtml(f.reason||'—')}</span></span>
-                <span style="opacity:.5; font-size:.75rem;">Datum: ${escHtml(f.entry_date||'—')}</span>
-                ${f.auto_flagged ? '<span class="badge badge-auto">Auto</span>' : '<span class="badge badge-flagged">Manuell</span>'}
+                <span style="opacity:.7;">Reason: <span style="color:#fb923c;">${escHtml(f.reason||'—')}</span></span>
+                <span style="opacity:.5; font-size:.75rem;">Date: ${escHtml(f.entry_date||'—')}</span>
+                ${f.auto_flagged ? '<span class="badge badge-auto">Auto</span>' : '<span class="badge badge-flagged">Manual</span>'}
             </div>
+        </div>`);
+    }
+
+    // GC ban / BA ban
+    if (r.data.gc_ban !== null && r.data.gc_ban !== undefined) {
+        sections.insertAdjacentHTML('beforeend', `
+        <div style="border:1px solid rgba(239,68,68,.35); border-radius:8px; padding:.75rem 1rem;">
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Global Chat Ban (gc_ban)</div>
+            <div style="font-size:.82rem; opacity:.8; word-break:break-word;">${escHtml(JSON.stringify(r.data.gc_ban))}</div>
+        </div>`);
+    }
+    if (r.data.ba_ban !== null && r.data.ba_ban !== undefined) {
+        sections.insertAdjacentHTML('beforeend', `
+        <div style="border:1px solid rgba(239,68,68,.35); border-radius:8px; padding:.75rem 1rem;">
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Bot-Wide Ban (ba_ban)</div>
+            <div style="font-size:.82rem; opacity:.8; word-break:break-word;">${escHtml(JSON.stringify(r.data.ba_ban))}</div>
         </div>`);
     }
 
     // Chatfilter violations block
     if (r.data.chatfilter_violations && r.data.chatfilter_violations.length) {
         const viol = r.data.chatfilter_violations;
-        const rows = viol.slice(0, 20).map(v => `<tr>
+        const rows = viol.slice(0, 30).map(v => `<tr>
             <td style="opacity:.5; white-space:nowrap; font-size:.73rem;">${escHtml(v.timestamp||'—')}</td>
-            <td>${escHtml(v.system||'—')}</td>
-            <td style="opacity:.55; font-size:.73rem;">${escHtml(v.sname||'—')}</td>
+            <td style="font-size:.73rem;">${escHtml(v.sname||'—')}</td>
+            <td style="font-size:.73rem;">${escHtml(v.cname||'—')}</td>
             <td><span class="badge badge-flagged" style="font-size:.68rem;">${escHtml(v.reason||'—')}</span></td>
-            <td style="max-width:200px; word-break:break-word; opacity:.7; font-size:.75rem;">${escHtml((v.message||'').slice(0,70))}${(v.message||'').length > 70 ? '…' : ''}</td>
+            <td style="max-width:240px; word-break:break-word; font-size:.75rem;">${escHtml(v.message||'—')}</td>
         </tr>`).join('');
         sections.insertAdjacentHTML('beforeend', `
-        <div style="border:1px solid rgba(255,255,255,.08); border-radius:8px; padding:.75rem 1rem;">
-            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Chatfilter-Verstöße (${viol.length})</div>
+        <div style="border:1px solid rgba(192,132,252,.2); border-radius:8px; padding:.75rem 1rem;">
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Chatfilter Violations (${viol.length})</div>
             <div style="overflow-x:auto;">
                 <table class="admin-table" style="font-size:.76rem;">
-                    <thead><tr><th>Zeit</th><th>System</th><th>Server</th><th>Grund</th><th>Nachricht</th></tr></thead>
-                    <tbody>${rows}${viol.length > 20 ? `<tr><td colspan="5" style="opacity:.4; font-style:italic; padding:.4rem;">…und ${viol.length-20} weitere</td></tr>` : ''}</tbody>
+                    <thead><tr><th>Time</th><th>Server</th><th>Channel</th><th>Reason</th><th>Message</th></tr></thead>
+                    <tbody>${rows}${viol.length > 30 ? `<tr><td colspan="5" style="opacity:.4; font-style:italic; padding:.4rem;">… and ${viol.length-30} more</td></tr>` : ''}</tbody>
                 </table>
             </div>
         </div>`);
     }
 
-    // Guild warnings block
+    // Guild warnings block (with individual entries)
     if (r.data.guild_warnings && r.data.guild_warnings.length) {
         const gw = r.data.guild_warnings;
+        const totalWarns = gw.reduce((s, g) => s + g.count, 0);
+        const warnRows = gw.flatMap(g =>
+            (g.entries||[]).map(w => `<tr>
+                <td style="opacity:.5; white-space:nowrap; font-size:.73rem;">${escHtml(w.date||'—')}</td>
+                <td style="font-size:.75rem; font-weight:600;">${escHtml(g.guild_name||g.guild_id)}</td>
+                <td style="word-break:break-word; font-size:.75rem;">${escHtml(w.reason||'—')}</td>
+                <td style="opacity:.6; font-size:.73rem;">${escHtml(w.mod||'—')}</td>
+                <td style="opacity:.4; font-size:.7rem; font-family:monospace;">${escHtml(w.id||'—')}</td>
+            </tr>`)
+        ).join('');
         sections.insertAdjacentHTML('beforeend', `
-        <div style="border:1px solid rgba(255,255,255,.08); border-radius:8px; padding:.75rem 1rem;">
-            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Verwarnungen in Servern (${gw.length} Server)</div>
-            <div style="display:flex; flex-direction:column; gap:.3rem;">
-                ${gw.map(g => `<div style="display:flex; align-items:center; gap:.5rem; font-size:.8rem; padding:.3rem .5rem; background:rgba(255,255,255,.03); border-radius:4px;">
-                    <span style="font-weight:600;">${escHtml(g.guild_name||g.guild_id)}</span>
-                    <span style="opacity:.4; font-size:.7rem;">${g.guild_id}</span>
-                    <span class="badge badge-auto">${g.count} Verwarnung${g.count!==1?'en':''}</span>
-                </div>`).join('')}
+        <div style="border:1px solid rgba(251,146,60,.2); border-radius:8px; padding:.75rem 1rem;">
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Warnings (${totalWarns} across ${gw.length} server${gw.length!==1?'s':''})</div>
+            <div style="overflow-x:auto;">
+                <table class="admin-table" style="font-size:.76rem;">
+                    <thead><tr><th>Date</th><th>Server</th><th>Reason</th><th>Moderator</th><th>ID</th></tr></thead>
+                    <tbody>${warnRows}</tbody>
+                </table>
             </div>
         </div>`);
     }
@@ -1229,21 +1274,75 @@ async function searchUser() {
     // Temp actions block
     if (r.data.temp_actions && r.data.temp_actions.length) {
         const ta = r.data.temp_actions;
+        const taRows = ta.map(t => `<tr>
+            <td><span class="badge badge-auto">${escHtml(t.type)}</span></td>
+            <td style="font-size:.75rem; font-weight:600;">${escHtml(t.guild_name||t.guild_id)}</td>
+            <td style="opacity:.7; font-size:.74rem;">${escHtml(t.reason||'—')}</td>
+            <td style="opacity:.5; white-space:nowrap; font-size:.73rem;">${escHtml(t.expires_at||'—')}</td>
+        </tr>`).join('');
         sections.insertAdjacentHTML('beforeend', `
         <div style="border:1px solid rgba(251,146,60,.25); border-radius:8px; padding:.75rem 1rem;">
-            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Aktive Temp-Actions (${ta.length})</div>
-            <div style="display:flex; flex-direction:column; gap:.3rem;">
-                ${ta.map(t => `<div style="display:flex; align-items:center; gap:.5rem; font-size:.8rem; padding:.3rem .5rem; background:rgba(251,146,60,.06); border-radius:4px;">
-                    <span class="badge badge-auto">${escHtml(t.type)}</span>
-                    <span style="opacity:.7;">${escHtml(t.guild_name||t.guild_id)}</span>
-                    <span style="opacity:.45; font-size:.72rem;">Läuft ab: ${escHtml(t.expires_at||'—')}</span>
-                </div>`).join('')}
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Active Temp Actions (${ta.length})</div>
+            <div style="overflow-x:auto;">
+                <table class="admin-table" style="font-size:.76rem;">
+                    <thead><tr><th>Type</th><th>Server</th><th>Reason</th><th>Expires</th></tr></thead>
+                    <tbody>${taRows}</tbody>
+                </table>
+            </div>
+        </div>`);
+    }
+
+    // Open tickets block
+    if (r.data.open_tickets && r.data.open_tickets.length) {
+        const ot = r.data.open_tickets;
+        const otRows = ot.map(t => {
+            const created = t.created_at ? new Date(t.created_at * 1000).toLocaleString('en-GB') : '—';
+            return `<tr>
+                <td style="font-size:.75rem; font-weight:600;">${escHtml(t.guild_name||t.guild_id)}</td>
+                <td style="font-size:.75rem;">${escHtml(t.title||'—')}</td>
+                <td style="max-width:200px; word-break:break-word; font-size:.74rem; opacity:.7;">${escHtml(t.message||'—')}</td>
+                <td><span class="badge badge-ok" style="font-size:.68rem;">${escHtml(t.status||'open')}</span></td>
+                <td style="opacity:.5; font-size:.72rem; white-space:nowrap;">${escHtml(created)}</td>
+            </tr>`;
+        }).join('');
+        sections.insertAdjacentHTML('beforeend', `
+        <div style="border:1px solid rgba(96,165,250,.2); border-radius:8px; padding:.75rem 1rem;">
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Open Tickets (${ot.length})</div>
+            <div style="overflow-x:auto;">
+                <table class="admin-table" style="font-size:.76rem;">
+                    <thead><tr><th>Server</th><th>Title</th><th>Initial Message</th><th>Status</th><th>Created</th></tr></thead>
+                    <tbody>${otRows}</tbody>
+                </table>
+            </div>
+        </div>`);
+    }
+
+    // Closed transcripts block
+    if (r.data.transcripts && r.data.transcripts.length) {
+        const tr = r.data.transcripts;
+        const trRows = tr.map(t => `<tr>
+            <td style="font-size:.75rem;">${escHtml(t.title||'—')}</td>
+            <td style="max-width:180px; word-break:break-word; font-size:.74rem; opacity:.7;">${escHtml(t.initial_message||'—')}</td>
+            <td style="opacity:.5; font-size:.73rem;">${escHtml(t.guild_id||'—')}</td>
+            <td style="opacity:.6; font-size:.73rem;">${escHtml(t.closed_by||'—')}</td>
+            <td style="opacity:.5; white-space:nowrap; font-size:.72rem;">${escHtml((t.closed_on||'—').slice(0,16))}</td>
+            <td style="opacity:.4; font-size:.72rem;">${t.message_count}</td>
+            <td><a href="/?ticket_transcript=${encodeURIComponent(t.id)}" target="_blank" class="btn-sm-outline" style="font-size:.7rem; padding:.15rem .4rem;">View</a></td>
+        </tr>`).join('');
+        sections.insertAdjacentHTML('beforeend', `
+        <div style="border:1px solid rgba(52,211,153,.2); border-radius:8px; padding:.75rem 1rem;">
+            <div style="font-size:.68rem; opacity:.4; text-transform:uppercase; letter-spacing:.08em; margin-bottom:.5rem;">Closed Ticket Transcripts (${tr.length})</div>
+            <div style="overflow-x:auto;">
+                <table class="admin-table" style="font-size:.76rem;">
+                    <thead><tr><th>Title</th><th>Initial Message</th><th>Server ID</th><th>Closed By</th><th>Closed On</th><th>Msgs</th><th></th></tr></thead>
+                    <tbody>${trRows}</tbody>
+                </table>
             </div>
         </div>`);
     }
 
     if (!sections.children.length) {
-        sections.innerHTML = '<div style="opacity:.4; font-size:.82rem; padding:.5rem;">Keine detaillierten Daten für diesen User gefunden.</div>';
+        sections.innerHTML = '<div style="opacity:.4; font-size:.82rem; padding:.5rem;">No detailed data found for this user.</div>';
     }
 
     wrap.style.display = 'block';
@@ -1252,9 +1351,9 @@ async function searchUser() {
 async function deleteUserData() {
     if (!_currentSearchUid) return;
     const confirmed = confirm(
-        `Alle Daten von "${_currentSearchName}" (${_currentSearchUid}) löschen?\n\n` +
-        `• Prism-Profil\n• Flagged-User-Eintrag\n• Chatfilter-Logs\n• Verwarnungen\n• Temp-Actions\n\n` +
-        `Eine DM wird an den User gesendet. Dies kann nicht rückgängig gemacht werden!`
+        `Delete ALL data for "${_currentSearchName}" (${_currentSearchUid})?\n\n` +
+        `• Prism profile\n• Flagged user entry\n• Chatfilter logs\n• Warnings\n• Temp actions\n\n` +
+        `A DM will be sent to the user. This cannot be undone!`
     );
     if (!confirmed) return;
 
@@ -1266,15 +1365,15 @@ async function deleteUserData() {
         _currentSearchName = null;
         share && await pollData();
     } else {
-        alert('Fehler: ' + r.message);
+        alert('Error: ' + r.message);
     }
 }
 
 async function sendUserData() {
     if (!_currentSearchUid) return;
-    if (!confirm(`Alle gespeicherten Daten von "${_currentSearchName}" (${_currentSearchUid}) per Discord-DM an den User senden?`)) return;
+    if (!confirm(`Send all stored data for "${_currentSearchName}" (${_currentSearchUid}) via Discord DM?`)) return;
     const r = await doAction({ action: 'send_user_data', user_id: _currentSearchUid });
-    alert(r.ok ? '✓ ' + r.message : 'Fehler: ' + r.message);
+    alert(r.ok ? '✓ ' + r.message : 'Error: ' + r.message);
 }
 
 // ── Admin Actions ─────────────────────────────────────────────


### PR DESCRIPTION
- search_user now includes Prism events (last 30 with type/reason/guild/time),
  full warning entries per guild (reason, mod, date, id), open tickets per guild,
  closed ticket transcripts (matched by username), gc_ban/ba_ban global bans
- send_user_data DM rewritten in English with multiple detailed embeds:
  overview, prism events table, chatfilter violations with full message,
  warnings per server, temp actions
- delete_user_data DM translated to English
- Admin panel UI text updated to English (search box, buttons, confirm dialogs,
  status messages, section headers)
