### PR TITLE
Fix false-positive permission warnings in dashboard channel check

### DIFF
--- a/assets/dash/dash.py
+++ b/assets/dash/dash.py
@@ -2594,11 +2594,15 @@ def dash_web(app: quart.Quart, bot: commands.AutoShardedBot):
             return quart.jsonify({"error": "Missing required fields"}), 400
 
         try:
-            guild = await bot.fetch_guild(guild_id)
+            # Prefer cached guild so that channel.guild and bot_member.guild
+            # reference the same object, avoiding permission calculation
+            # mismatches when fetch_guild() creates a guild object outside
+            # the bot's internal state cache.
+            guild = bot.get_guild(guild_id)
+            if guild is None:
+                guild = await bot.fetch_guild(guild_id)
             assert bot.user is not None, "Bot user unknown"
             bot_member = await guild.fetch_member(bot.user.id)
-            if not bot_member:
-                bot_member = await guild.fetch_member(bot.user.id)
 
             if system == "bot_general":
                 permissions = bot_member.guild_permissions


### PR DESCRIPTION
bot.fetch_guild() creates a Guild object that is NOT inserted into the
bot's internal state cache. When guild.fetch_channel() is subsequently
called it resolves channel.guild via self._state._get_guild(), which
returns the *cached* guild (G_cached), not the freshly fetched one
(G_fetched). This left channel.guild and bot_member.guild pointing at
different guild instances.

discord.py's permissions_for() resolves bot_member.roles through
bot_member.guild (G_fetched) but computes the @everyone base permissions
through channel.guild (G_cached). The object mismatch can cause certain
role permissions to be missed, making valid permissions appear absent.

Fix: use bot.get_guild() (cached) as the primary source so that all
objects share the same guild instance; fall back to fetch_guild() only
when the guild is not in cache.

https://claude.ai/code/session_01Nw7jGYVJjdGyBQKK4qtTaQ